### PR TITLE
Always use '/' as class path resources separator as it does not depend on OS

### DIFF
--- a/stacktrace-decoroutinator-jvm-agent-common/src/main/kotlin/utils-jvm-agent-common.kt
+++ b/stacktrace-decoroutinator-jvm-agent-common/src/main/kotlin/utils-jvm-agent-common.kt
@@ -4,7 +4,6 @@ import dev.reformator.stacktracedecoroutinator.common.BASE_CONTINUATION_CLASS_NA
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.ClassNode
 import java.lang.instrument.Instrumentation
-import java.nio.file.FileSystems
 import kotlin.coroutines.suspendCoroutine
 
 val BASE_CONTINUATION_INTERNAL_CLASS_NAME = BASE_CONTINUATION_CLASS_NAME.replace('.', '/')
@@ -41,7 +40,7 @@ fun addDecoroutinatorClassFileTransformers(inst: Instrumentation) {
     )
     Class.forName(BASE_CONTINUATION_CLASS_NAME)
     val stubClassName = _preloadStub::class.java.name
-    val stubClassPath = stubClassName.replace(".", FileSystems.getDefault().separator) + ".class"
+    val stubClassPath = stubClassName.replace('.', '/') + ".class"
     val stubClassBody = ClassLoader.getSystemResourceAsStream(stubClassPath).use { classBodyStream ->
         classBodyStream.readBytes()
     }


### PR DESCRIPTION
The instrumentation breaks on Windows where file path separator is '\' while class path resource separator is '/'
![image](https://user-images.githubusercontent.com/25208879/176686741-b4ce425c-e9d2-41b7-85e7-9d0eec69cb13.png)
